### PR TITLE
Laravel 10 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,26 +10,26 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 8.0, 8.1]
-        laravel: [8.*, 9.*]
+        php: [8.0, 8.1, 8.2]
+        laravel: [9.*, 10.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.*
+          - laravel: 10.*
+            testbench: 8.*
         exclude:
-          - laravel: 9.*
-            php: 7.4
+          - laravel: 10.*
+            php: 8.0
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -40,6 +40,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: sqlite
           coverage: none
+          tools: composer:v2
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ npm-debug.log
 composer.lock
 .idea
 .phpunit.result.cache
+.phpunit.cache/test-results
 phpunit.xml

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Our email address is [photoware@hihaho.com](mailto:photoware@hihaho.com)
 
 Simply add the following line to your ```composer.json``` and run ```composer update```
 ```
-"hihaho/laravel-encryptable-trait": "^v1.3"
+"hihaho/laravel-encryptable-trait": "^v3.0"
 ```
 Or use composer to add it with the following command
 ```bash
@@ -31,8 +31,8 @@ composer require hihaho/laravel-encryptable-trait
 ```
 
 ## Requirements
-- illuminate/encryption ^8.75 or ^9.0
-- PHP 7.4, 8.0 or 8.1
+- illuminate/encryption ^9.0 or ^10.0
+- PHP 8.0 or 8.1 or 8.2
 
 # Usage
 Simply add the trait to your models and set the ```$encryptable``` to an array of values that need to be encrypted.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/hihaho/laravel-encryptable-trait",
   "license": "MIT",
   "type": "library",
-  "version": "v2.0.0",
+  "version": "v3.0.0",
   "authors": [
     {
       "name": "Robert Boes",
@@ -22,13 +22,13 @@
     }
   ],
   "require": {
-    "php": "^7.4|^8.0",
-    "illuminate/encryption": "^8.75|^9.0"
+    "php": "^8.0",
+    "illuminate/encryption": "^9.0|^10.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.3.3",
-    "orchestra/testbench": "^6.0|^7.0",
-    "phpunit/phpunit": "^8.5.23|^9.0"
+    "orchestra/testbench": "^7.0|^8.0",
+    "phpunit/phpunit": "^9.2|^10.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
   ],
   "require": {
     "php": "^8.0",
-    "illuminate/encryption": "^9.0|^10.0"
+    "illuminate/encryption": "^9.34|^10.0"
   },
   "require-dev": {
-    "mockery/mockery": "^1.3.3",
-    "orchestra/testbench": "^7.0|^8.0",
+    "mockery/mockery": "^1.5.1",
+    "orchestra/testbench": "^7.9|^8.0",
     "phpunit/phpunit": "^9.2|^10.0"
   },
   "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         backupGlobals="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
+         backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
Add Laravel 10 support
Add PHP 8.2 support
Drop Laravel 8 support
Drop PHP 7.4 support

A minimum of Laravel 9.34 is needed to support PHP 8.2 due to `Carbon\Carbon` version in prior Laravel versions not supporting PHP 8.2